### PR TITLE
tweaks to image/video post

### DIFF
--- a/app/_posts/2021-08-04-image-video-upload-post.md
+++ b/app/_posts/2021-08-04-image-video-upload-post.md
@@ -11,24 +11,23 @@ With these new multimedia options in H2O, authors are able to use the text edito
 
 <!--more-->
 
-<p style="text-align:center;"><img src="/assets/images/image-upload-example.png" alt="screenshot of image uploaded to an H2O casebook" width="600" height="425"></p>
+![screenshot of image uploaded to an H2O casebook](/assets/images/image-upload-example.png){: .img-responsive }
 
 Complementing this change, we have adapted our "Text" resources to be called "Custom Content". These resources now feature a responsive tag that will adapt based on the type of content authors include. For example, a resource that only includes text will be tagged as such in the main casebook view. 
 
-<p style="text-align:center;"><img src="/assets/images/Questions-to-consider-text.png" alt="add image button" width="700" height="75"></p>
+![resource labeled as text](/assets/images/Questions-to-consider-text.png){: .img-responsive }
 
 A resource that includes video or images will instead be tagged as multimedia. 
 
-<p style="text-align:center;"><img src="/assets/images/Video-overview-multimedia.png" alt="add image button" width="700" height="75"></p>
+![resource labeled as multimedia](/assets/images/Video-overview-multimedia.png){: .img-responsive }
 
 Authors can use these tools within any text editor in their books. Follow the steps below to get started, and please be in touch with us at info@opencasebook.org with questions or comments. 
 
 ### Adding Images:
 
 1. Navigate to the “Edit” tab of an existing resource, or create a new Custom Content resource. 
-2. Click into the text editor where you want to add an image, and then click the three dots along the formatting bar at the top. From there, click the image icon.
-<br>
-<img src="/assets/images/add-image.png" alt="add image button" width="600" height="110">
+2. Click into the text editor where you want to add an image, and then click the three dots along the formatting bar at the top. From there, click the image icon.<br />
+![add image button](/assets/images/add-image.png)
 3. You will be given the option to upload your own image, or, if the image is posted online, to insert the appropriate URL.
 4. Once you’ve selected the image you want to add, you can choose how you’d like to position it in your book using the “Class” dropdown. Click save to close the Insert/Edit Image window. 
 5. Click save along the right side of your book, and navigate to the “Preview” tab to review your work.
@@ -36,9 +35,8 @@ Authors can use these tools within any text editor in their books. Follow the st
 ### Adding Videos:
 
 1. Navigate to the “Edit” tab of an existing resource, or create a new Custom Content resource. 
-2. Click into the text editor where you want to embed a video, and then click the three dots along the formatting bar at the top. From there, click the video icon.
-<br>
-<img src="/assets/images/add-video.png" alt="add video button" width="600" height="110">
+2. Click into the text editor where you want to embed a video, and then click the three dots along the formatting bar at the top. From there, click the video icon.<br />
+![add video button](/assets/images/add-video.png)
 3. You will be given the option to paste in the URL or the embed code, which you can find on the host site (YouTube or Vimeo).
 4. Click save to close the Insert/Edit Media window.
 5. Click save along the right side of your book, and navigate to the “Preview” tab to review your work.

--- a/app/_posts/2021-08-19-image-video-upload-post.md
+++ b/app/_posts/2021-08-19-image-video-upload-post.md
@@ -1,7 +1,6 @@
 ---
 title: Introducing images and video in H2O
 author: catherine-brobston
-date: 2021-08-04
 excerpt_separator: <!--more-->
 ---
 


### PR DESCRIPTION
Rather than specify height and width using HTML, here I'm adding the `.img-responsive` class using kramdown's [attribute list definition](https://kramdown.gettalong.org/syntax.html#attribute-list-definitions) syntax, which has the effect of centering -- see https://github.com/harvard-lil/h2o-static/blob/develop/app/_scss/bootstrap-helpers.scss#L102-L107 for the CSS in question.

The images in the list items don't get this class -- they seem fine without specifying size.

I've also fixed a couple of alt texts and changed the post date to today.